### PR TITLE
Add required web font from Google Fonts to index CSS

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,6 @@
+@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&family=Outfit:wght@300;400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;700&family=Outfit:wght@300;400;700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;


### PR DESCRIPTION
# Overview
This pull request fixes font issues by:
* Adding entries of Montserrat and Open Sans from Google Fonts to `index.css`