### PR TITLE
fix navbar state dont match and change path for most interest sports

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { BrowserRouter, Routes, Route, Link } from "react-router-dom";
 import { Layout } from "antd";
 import HeaderNavigation from './components/headerNavigation';
 import Home from './pages/home'
@@ -14,9 +14,11 @@ function App() {
         <BrowserRouter>
             <Layout>
                 <Header className=" bg-eeric-black-light flex">
-                    <div >
-                        <img src="/sotaTransparentBgLogo.svg" alt="SoTA" className=" h-14 pt-3" />
-                    </div>
+                    <Link to={'/'}>
+                        <div >
+                            <img src="/sotaTransparentBgLogo.svg" alt="SoTA" className=" h-14 pt-3" />
+                        </div>
+                    </Link>
                     <div className="w-full flex justify-center">
                         <HeaderNavigation />
                     </div>

--- a/src/components/headerNavigation.tsx
+++ b/src/components/headerNavigation.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Menu } from 'antd';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 
 const items = [
     {
@@ -26,8 +26,11 @@ const items = [
 ];
 
 const HeaderNavigation: React.FC = () => {
+    const location = useLocation();
+    const activeKey = items.find(item => location.pathname.includes(item.key))?.key || "home";
+
     return (
-        <Menu defaultSelectedKeys={['home']} mode="horizontal" className="bg-eeric-black-light w-fit font-primary text-xl">
+        <Menu selectedKeys={[activeKey]} mode="horizontal" className="bg-eeric-black-light w-fit font-primary text-xl">
             {items.map((item) => (
                 <Menu.Item key={item.key} className="text-white">
                     <Link to={item.path}>{item.label}</Link>

--- a/src/components/mostInterestSports.tsx
+++ b/src/components/mostInterestSports.tsx
@@ -40,7 +40,7 @@ const MostInterestSports = () => {
                 </div>
             </div>
             <div className="flex w-full justify-end pb-5 pr-5 text-white">
-                <a href="/medal">Overall audience page <ArrowRightOutlined /></a>
+                <a href="/audience">Overall audience page <ArrowRightOutlined /></a>
             </div>
         </div>
     )


### PR DESCRIPTION
|                           |                                                  |
|---------------------------|--------------------------------------------------|
| 🥶 |  **Navbar Highlight & Home Page Redirect Fix**  |
|                           |                                                  |
| 1.                        | Enhanced the navigation bar to dynamically highlight sections when double-arrow icons are clicked. |
|                           |                                                  |
| 2.                        | Resolved the redirect issue so that clicking 'Overall Audience' now correctly takes you to the 'Audience' page instead of the 'Medal' page. |
|                           |                                                  |
| 3.                        | Logo being clicked on navigation bar should redirect to home page |

https://github.com/SPaM-Skill-Issue/sota-frontend/assets/92836314/70f159ea-d6c9-46ec-a3a8-6c8539947464

