### PR TITLE
Fixing table responsiveness

### DIFF
--- a/src/components/tableComponent.tsx
+++ b/src/components/tableComponent.tsx
@@ -17,13 +17,14 @@ export interface SotaTableProps<T> {
     columns?: ColumnType[];
     refreshRate?: number;
     tableProps?: Omit<TableProps<T>, "dataSource" | "loading">;
+    seamless?: boolean;
     dataProcess: DataProcessor<T>;
 }
 
 const SotaTable: React.FC<Partial<SotaTableProps<any>>> = (props) => {
-    
-    const [ isLoaded, setLoaded ] = useState<boolean>(false);
-    const [ data, setData ] = useState<TableRow<any>[]>([]);
+
+    const [isLoaded, setLoaded] = useState<boolean>(false);
+    const [data, setData] = useState<TableRow<any>[]>([]);
 
     const fetchData = async (): Promise<any> => {
         const res = await fetch(props.src!);
@@ -32,10 +33,11 @@ const SotaTable: React.FC<Partial<SotaTableProps<any>>> = (props) => {
     }
 
     const update = () => {
+        if (!props.seamless) setLoaded(false);
         fetchData().then((res) => {
             const data: TableRow<any>[] = props.dataProcess!.apply(null, [res]);
             setData(data);
-            (data.length != 0 && !isLoaded) ? setLoaded(true) : false;
+            setLoaded(true);
         });
     }
 
@@ -48,14 +50,14 @@ const SotaTable: React.FC<Partial<SotaTableProps<any>>> = (props) => {
         update();
         const interval = setInterval(() => {
             update();
-        }, props.refreshRate!*1000);
+        }, props.refreshRate! * 1000);
         return () => clearInterval(interval);
     }, [props.src]);
     /* eslint-enable */
 
     return (
         <Table dataSource={data} loading={!isLoaded} {...props.tableProps}>
-            { props.columns?.map(col => col) }
+            {props.columns?.map(col => col)}
         </Table>
     );
 
@@ -63,7 +65,8 @@ const SotaTable: React.FC<Partial<SotaTableProps<any>>> = (props) => {
 
 SotaTable.defaultProps = {
     columns: [],
-    refreshRate: 30
+    refreshRate: 60,
+    seamless: true
 };
 
 export { SotaTable };

--- a/src/components/tables/medalByCountry.tsx
+++ b/src/components/tables/medalByCountry.tsx
@@ -8,6 +8,7 @@ import ReactCountryFlag from "react-country-flag";
 const opts: SotaTableProps<CountryEntry> = {
     src: "https://sota-backend.fly.dev/medals",
     dataProcess: (data): TableRow<CountryEntry>[] => {
+        if (Object.keys(data).length === 0) return [];
         const result: TableRow<CountryEntry>[] = [];
         for (const [country, medals] of Object.entries<MedalObject>(data)) {
             const total = medals.gold + medals.silver + medals.bronze;
@@ -64,17 +65,17 @@ const opts: SotaTableProps<CountryEntry> = {
         )} align="center" />),
         (<Table.Column key="gold" dataIndex="gold" title={
             <div className="flex w-full justify-center content-center">
-                <MedalIcon place={1} size={28} fill="#D6AF36"/>
+                <MedalIcon place={1} size={28} fill="#D6AF36" />
             </div>
         } align="center" />),
         (<Table.Column key="silver" dataIndex="silver" title={
             <div className="flex w-full justify-center content-center">
-                <MedalIcon place={2} size={28} fill="#A7A7AD"/>
+                <MedalIcon place={2} size={28} fill="#A7A7AD" />
             </div>
         } align="center" />),
         (<Table.Column key="bronze" dataIndex="bronze" title={
             <div className="flex w-full justify-center content-center">
-                <MedalIcon place={3} size={28} fill="#CC7B12"/>
+                <MedalIcon place={3} size={28} fill="#CC7B12" />
             </div>
         } align="center" />),
     ],
@@ -82,11 +83,11 @@ const opts: SotaTableProps<CountryEntry> = {
         size: "small",
         tableLayout: "fixed",
         pagination: {
-            position: [ "topRight" ]
+            position: ["topRight"]
         }
     }
 }
 
-const OverallMedalByCountry: React.FC = () => ( <SotaTable {...opts} /> );
+const OverallMedalByCountry: React.FC = () => (<SotaTable {...opts} />);
 
 export default OverallMedalByCountry;

--- a/src/components/tables/medalByCountryHomePage.tsx
+++ b/src/components/tables/medalByCountryHomePage.tsx
@@ -9,6 +9,7 @@ import { getCountryName } from "../../util/iso31661a2";
 const opts: SotaTableProps<CountryEntry> = {
     src: "https://sota-backend.fly.dev/medals",
     dataProcess: (data): TableRow<CountryEntry>[] => {
+        if (Object.keys(data).length === 0) return [];
         const result: TableRow<CountryEntry>[] = [];
         for (const [country, medals] of Object.entries<MedalObject>(data)) {
             const total = medals.gold + medals.silver + medals.bronze;
@@ -52,11 +53,11 @@ const opts: SotaTableProps<CountryEntry> = {
     },
     columns: [
         (<Table.Column key="rank" dataIndex="rank"
-        className="before:content-['#'] before:font-bold before:font-primary font-bold font-primary" width={60}/>),
+            className="before:content-['#'] before:font-bold before:font-primary font-bold font-primary" width={60} />),
         (<Table.Column key="country" dataIndex="country" render={(c: string) => (
             <Tooltip className="font-primary" title={getCountryName(c)} placement="left">
-            <ReactCountryFlag countryCode={c} svg style={{ marginRight: '1rem', width: '1.5rem', height: '1.5rem' }}/>
-            {getCountryName(c)}
+                <ReactCountryFlag countryCode={c} svg style={{ marginRight: '1rem', width: '1.5rem', height: '1.5rem' }} />
+                {getCountryName(c)}
             </Tooltip>
         )} ellipsis={true} className="font-primary font-bold" />),
         (<Table.Column key="total" dataIndex="total" render={(t: number) => (
@@ -66,17 +67,17 @@ const opts: SotaTableProps<CountryEntry> = {
         } align="center" />),
         (<Table.Column key="gold" dataIndex="gold" title={
             <div className="flex w-full justify-center content-center">
-                <MedalIcon place={1} size={32} fill="#D6AF36"/>
+                <MedalIcon place={1} size={32} fill="#D6AF36" />
             </div>
         } align="center" />),
         (<Table.Column key="silver" dataIndex="silver" title={
             <div className="flex w-full justify-center content-center">
-                <MedalIcon place={2} size={32} fill="#A7A7AD"/>
+                <MedalIcon place={2} size={32} fill="#A7A7AD" />
             </div>
         } align="center" />),
         (<Table.Column key="bronze" dataIndex="bronze" title={
             <div className="flex w-full justify-center content-center">
-                <MedalIcon place={3} size={32} fill="#CC7B12"/>
+                <MedalIcon place={3} size={32} fill="#CC7B12" />
             </div>
         } align="center" />),
     ],
@@ -87,6 +88,6 @@ const opts: SotaTableProps<CountryEntry> = {
     }
 };
 
-const OverallMedalByCountryHomePage: React.FC = () => ( <SotaTable {...opts} /> );
+const OverallMedalByCountryHomePage: React.FC = () => (<SotaTable {...opts} />);
 
 export default OverallMedalByCountryHomePage;

--- a/src/components/tables/medalForSingleCountry.tsx
+++ b/src/components/tables/medalForSingleCountry.tsx
@@ -6,6 +6,7 @@ import MedalIcon from "../medalIcon";
 
 const opts: Omit<SotaTableProps<SportEntry>, "src"> = {
     dataProcess: (data): TableRow<SportEntry>[] => {
+        if (Object.keys(data).length === 0) return [];
         const sports: SportEntry[] = data["individual_sports"];
         sports.forEach((s) => {
             s.sub_sports.sort((a, b) => {
@@ -17,11 +18,11 @@ const opts: Omit<SotaTableProps<SportEntry>, "src"> = {
                 if (a.silver! > b.silver!) return -1;
                 return a.sub_name!.localeCompare(b.sub_name!) * -1;
             }),
-            s.sub_sports.forEach((ss) => {
-                ss.key = `${s.sport_id} - ${ss.sub_name}`,
-                ss.name = ss.sub_name
-                ss.total = ss.gold + ss.silver + ss.bronze
-            });
+                s.sub_sports.forEach((ss) => {
+                    ss.key = `${s.sport_id} - ${ss.sub_name}`,
+                        ss.name = ss.sub_name
+                    ss.total = ss.gold + ss.silver + ss.bronze
+                });
         });
         sports.sort((a, b) => {
             if (a.total! < b.total!) return 1;
@@ -62,40 +63,41 @@ const opts: Omit<SotaTableProps<SportEntry>, "src"> = {
         } align="center" />),
         (<Table.Column key="gold" dataIndex="gold" title={
             <div className="flex w-full justify-center content-center">
-                <MedalIcon place={1} size={32} fill="#D6AF36"/>
+                <MedalIcon place={1} size={32} fill="#D6AF36" />
             </div>
         } align="center" />),
         (<Table.Column key="silver" dataIndex="silver" title={
             <div className="flex w-full justify-center content-center">
-                <MedalIcon place={2} size={32} fill="#A7A7AD"/>
+                <MedalIcon place={2} size={32} fill="#A7A7AD" />
             </div>
         } align="center" />),
         (<Table.Column key="bronze" dataIndex="bronze" title={
             <div className="flex w-full justify-center content-center">
-                <MedalIcon place={3} size={32} fill="#CC7B12"/>
+                <MedalIcon place={3} size={32} fill="#CC7B12" />
             </div>
         } align="center" />),
     ],
     tableProps: {
         tableLayout: "fixed",
         pagination: false
-    }
+    },
+    seamless: false,
 }
 
 interface Props {
     country: string;
 }
 
-const MedalForSingleCountry: React.FC<Props> = (props) => { 
+const MedalForSingleCountry: React.FC<Props> = (props) => {
 
-    const [ src, setSrc ] = useState<string>('');
-    const [ loaded, setLoaded ] = useState<boolean>(false);
+    const [src, setSrc] = useState<string>('');
+    const [loaded, setLoaded] = useState<boolean>(false);
 
     useEffect(() => {
         setLoaded(false);
         if (props.country == '') {
             setSrc('');
-            return () => {};
+            return () => { };
         }
         setSrc(`https://sota-backend.fly.dev/medal/c/${props.country}`);
         setLoaded(true);

--- a/src/components/tables/medalForSingleSport.tsx
+++ b/src/components/tables/medalForSingleSport.tsx
@@ -8,6 +8,7 @@ import MedalIcon from "../medalIcon";
 
 const opts: Omit<SotaTableProps<CountryEntry>, "src"> = {
     dataProcess: (data): TableRow<CountryEntry>[] => {
+        if (Object.keys(data).length === 0) return [];
         const result: TableRow<CountryEntry>[] = [];
         const countries: CountryEntry[] = data["individual_countries"] || [];
         countries.forEach(e => {
@@ -66,24 +67,25 @@ const opts: Omit<SotaTableProps<CountryEntry>, "src"> = {
         } align="center" />),
         (<Table.Column key="gold" dataIndex="gold" title={
             <div className="flex w-full justify-center content-center">
-                <MedalIcon place={1} size={28} fill="#D6AF36"/>
+                <MedalIcon place={1} size={28} fill="#D6AF36" />
             </div>
         } align="center" />),
         (<Table.Column key="silver" dataIndex="silver" title={
             <div className="flex w-full justify-center content-center">
-                <MedalIcon place={2} size={28} fill="#A7A7AD"/>
+                <MedalIcon place={2} size={28} fill="#A7A7AD" />
             </div>
         } align="center" />),
         (<Table.Column key="bronze" dataIndex="bronze" title={
             <div className="flex w-full justify-center content-center">
-                <MedalIcon place={3} size={28} fill="#CC7B12"/>
+                <MedalIcon place={3} size={28} fill="#CC7B12" />
             </div>
         } align="center" />),
     ],
     tableProps: {
         tableLayout: "fixed",
         pagination: false
-    }
+    },
+    seamless: false,
 }
 
 interface Props {
@@ -92,14 +94,14 @@ interface Props {
 
 const MedalForSingleSport: React.FC<Props> = (props) => {
 
-    const [ src, setSrc ] = useState<string>('');
-    const [ loaded, setLoaded ] = useState<boolean>(false);
+    const [src, setSrc] = useState<string>('');
+    const [loaded, setLoaded] = useState<boolean>(false);
 
     useEffect(() => {
         setLoaded(false);
         if (Number.isNaN(props.sport)) {
             setSrc('');
-            return () => {};
+            return () => { };
         }
         setSrc(`https://sota-backend.fly.dev/medal/s/${props.sport}`);
         setLoaded(true);


### PR DESCRIPTION
# Overview
* The table before the PR has auto-update and loading, but doesn't show how they work properly. It creates a sense of unresponsiveness.
* The table in this PR changes:
  * When a source of data changes, the table goes into loading state.
  * Added a seamless loading option (enabled by default) to not show loading indicator.