### PR TITLE
Combo box display values should changes when category switches.

### DIFF
--- a/src/components/dropdownMenu.tsx
+++ b/src/components/dropdownMenu.tsx
@@ -8,12 +8,13 @@ interface DropdownMenuProps {
         key: string
     }[];
     handleSelect: (value:string) => void;
+    currentValue: string;
 }
 
-const DropdownMenu: React.FC<DropdownMenuProps> = ({ data, handleSelect }) => {
-
+const DropdownMenu: React.FC<DropdownMenuProps> = ({ data, handleSelect, currentValue }) => {
+    
     return (
-        <Select onSelect={handleSelect} className='w-1/3' >
+        <Select value={currentValue} onSelect={handleSelect} className='w-1/3'>
             {data.map(item => (
                 <Option key={item.key} value={item.key}>
                     {item.label}

--- a/src/components/filterSportCountry.tsx
+++ b/src/components/filterSportCountry.tsx
@@ -70,7 +70,7 @@ const FilterSportCountry: React.FC<sendData> = (sendData) => {
                 <Radio value="sports">Sports</Radio>
                 <Radio value="country">Country</Radio>
             </Radio.Group>
-            <DropdownMenu data={data} handleSelect={handleSelect} />
+            <DropdownMenu data={data} handleSelect={handleSelect} currentValue={dropdowndata}/>
         </div>
     );
 };

--- a/src/components/sportsIcons.tsx
+++ b/src/components/sportsIcons.tsx
@@ -39,8 +39,8 @@ const SportsIcons: React.FC<SportsIconsProps> = ({ sportId }) => {
     return (
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 504 504" xmlSpace="preserve">
             {data.map((sport) => (
-                sport.sport_icon.map((icon) => (
-                    <path d={icon} />
+                sport.sport_icon.map((icon, index) => (
+                    <path key={`${sport.sport_id}}-${index}`} d={icon} />
                 ))
             ))}
         </svg>

--- a/src/pages/sports.tsx
+++ b/src/pages/sports.tsx
@@ -58,7 +58,7 @@ const Sports: React.FC = () => {
                 </div>
             ) : (
                 <div className='scrollable-container mt-10 overflow-y-auto h-[70vh]'>
-                    <div className='grid grid-cols-5 justify-evenly'>
+                    <div className='grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 justify-evenly'>
                         {filteredSportsIcons.map((icon) => (
                             <div
                                 key={icon.sportId}


### PR DESCRIPTION
# Minor Bug: Combo Box Values Not Updating Correctly

## Description:
The values displayed on the combo box should change or reset when a new filter category is selected.

![Combo Box Issue](https://github.com/SPaM-Skill-Issue/sota-frontend/assets/92836314/9b1a86b3-f668-4adf-a11b-9eb75b8c1ec8)

----------------------------------------------------------------------------------------------------------------------------
<br/>

## Note that now the combo box will display name of sport with first sport id as default not a empty string.

### Previous Behavior:
![Previous Combo Box Display](https://github.com/SPaM-Skill-Issue/sota-frontend/assets/92836314/b3d7e16f-e2fa-4889-bd8a-1473deeef8de)

### Updated Behavior:
![Updated Combo Box Display](https://github.com/SPaM-Skill-Issue/sota-frontend/assets/92836314/015fbf52-168d-4dbc-8a73-243d532e082b)

I also resolve the unique key warning a bit on sportIcons.
