### PR TITLE
Hotfix: sport icon not show on Safari

### DIFF
--- a/src/components/sportCard.tsx
+++ b/src/components/sportCard.tsx
@@ -7,7 +7,7 @@ interface SportCardProps {
 const SportCard: React.FC<SportCardProps> = ({ sportName, sportIcon, color }) => {
     return (
         <div className="flex-row w-fit">
-            <div style={{ fill: color, width: 160 }} className="flex justify-center">
+            <div style={{ fill: color, width: 160, height: 160 }} className="flex justify-center">
                 {sportIcon}
             </div>
             <div style={{ color: color }} className="flex justify-center font-body text-xl mb-5">


### PR DESCRIPTION
## What I have done in this PR
- Add height in style to show icon

### Before
<img width="720" alt="Screen Shot 2566-11-23 at 23 04 37" src="https://github.com/SPaM-Skill-Issue/sota-frontend/assets/89629829/890f5a1c-65d6-41cc-9188-7260618c0ec9">
<img width="720" alt="Screen Shot 2566-11-23 at 23 05 29" src="https://github.com/SPaM-Skill-Issue/sota-frontend/assets/89629829/8893f292-3a91-4352-8fd1-2482635b6d18">

### After
<img width="720" alt="Screen Shot 2566-11-23 at 23 05 49" src="https://github.com/SPaM-Skill-Issue/sota-frontend/assets/89629829/487d059e-ef8f-4bce-b9f3-491d57279229">
<img width="720" alt="Screen Shot 2566-11-23 at 23 05 44" src="https://github.com/SPaM-Skill-Issue/sota-frontend/assets/89629829/d5e823fa-2496-4f7e-a6d7-db74853eb2fb">
